### PR TITLE
fix: fix upstream bug in smooth-dnd where animationDuration has no default

### DIFF
--- a/packages/lib/src/components/Container.js
+++ b/packages/lib/src/components/Container.js
@@ -47,7 +47,7 @@ export default defineComponent({
     dragClass: String,
     dropClass: String,
     dragBeginDelay: Number,
-    animationDuration: Number,
+    animationDuration: { type: Number, default: 250 },
     getChildPayload: Function,
     shouldAnimateDrop: Function,
     shouldAcceptDrop: Function,


### PR DESCRIPTION
In the smooth-dnd documentaiton, it says `animationDuration` has a default of 250, but that's not true (there is none specified). This results in items snapping back suddenly when released.

That package is pretty dusty and I don't expect any PRs to be merged, so how about we fix it in this package?