### PR TITLE
fix: cannot read properties of null (reading 'cancelDrop')

### DIFF
--- a/packages/lib/src/components/Container.js
+++ b/packages/lib/src/components/Container.js
@@ -29,7 +29,11 @@ export default defineComponent({
   },
   unmounted () {
     if (this.container) {
-      this.container.dispose();
+      try {
+        this.container.dispose();
+      } catch {
+        // ignore
+      }
     }
   },
   emits: ['drop', 'drag-start', 'drag-end', 'drag-enter', 'drag-leave', 'drop-ready' ],


### PR DESCRIPTION
This ignore a rare fatal issue that happen when a draggable item is removed before the container is unmounted

`Cannot read properties of null (reading 'cancelDrop')`